### PR TITLE
feat: added support for strongly typed `Actions` via generics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,22 @@
-function consecute(): Actions {
-  const topics: Topics = {};
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+function consecute<TEventMap extends EventMapBase = EventMapBase>(): Actions<TEventMap> {
+  const topics: Partial<Topics<TEventMap>> = {};
 
   return {
-    subscribe: (topic: string, hook: Hook) => {
+    subscribe: (topic, hook) => {
       if (!topics.hasOwnProperty.call(topics, topic)) topics[topic] = [];
 
-      const index = topics[topic].push(hook) - 1;
+      const index = topics[topic]!.push(hook) - 1;
 
       return {
         remove: () => delete topics?.[topic]?.[index],
       };
     },
-    publish: (topic: string, ...args: Parameters<Hook>) => new Promise((resolve, reject) => {
+    publish: (topic, ...args) => new Promise((resolve, reject) => {
       if (!topics.hasOwnProperty.call(topics, topic)) reject(new Error(`Topic "${topic}" does not exist.`));
 
-      return Promise.allSettled(topics[topic].map((hook) => hook(...args)))
+      return Promise.allSettled(topics[topic]!.map((hook) => hook(...args)))
         .then((result) => resolve(result));
     }),
     clear: () => {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,19 +1,24 @@
 /* eslint-disable */
 
-interface Topics {
-  [key: string]: Array<Hook>,
-}
+type EventMapBase = Record<string, any>;
 
-type Hook = (...args: any) => any;
+type Topics<TEventMap extends EventMapBase> = { [key in keyof TEventMap]: Array<Hook<TEventMap[key]>> };
+  
+type Hook<TArgs> = (...args: TArgs extends Array<unknown> ? TArgs : [TArgs]) => any;
 
-interface Actions {
-  clear: () => void,
-  subscribe: (topic: string, hook: Hook) => {
-    remove: () => void,
+interface Actions<TEventMap extends EventMapBase> {
+  clear(): void;
+  subscribe<TName extends keyof TEventMap>(topic: TName, hook: Hook<TEventMap[TName]>): {
+    remove(): void,
   },
-  publish: (topic: string, ...args: Parameters<Hook>) => void,
+  publish<TName extends keyof TEventMap>(topic: TName, ...args: TEventMap[TName]): void,
 }
 
 declare module 'consecute' {
-  export default function consecute(): Actions;
+  export type EventMapBase = Record<string, any>;
+
+  const instance: Actions<EventMapBase>;
+
+  export default instance;
+  export function consecute<TEventMap extends EventMapBase = EventMapBase>(): Actions<TEventMap>;
 }


### PR DESCRIPTION
## Description

This PR adds support for specifying a map of event names to their arguments via a generic on the `consecute` function. I have added a default of `Record<string, any>` (which the default instance uses) as not to introduce a breaking change. 

```typescript
interface MyEventMap extends EventMapBase {
  binga: number;
  bingo: { a: number, b: string };
  bingu: [string, number, boolean];
}

const customInstance = consecute<MyEventMap>();

customInstance.subscribe('binga', (event) => {
//                                 ^^^^^ This has the type `number`
});

customInstance.subscribe('bingo', (event) => {
//                                 ^^^^^ This has the type `{ a: number, b: string }`
});

customInstance.subscribe('bingu', (one, two, three) => {
//                                 ^^^^^^^^^^^^^^^ These have the type `string`, `number` and `boolean` respectively
});
```

In the case where you would want to send an array as a standalone argument (not spread), you would do this

```typescript
interface MyEventMap extends EventMapBase {
  bingy: [Array<string>];
}

const customInstance = consecute<MyEventMap>();

customInstance.subscribe('bingo', (event) => {
//                                 ^^^^^ This has the type `Array<string>`
});
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)